### PR TITLE
hide triangle in smartphone layout, fix #1

### DIFF
--- a/tooltips.scss
+++ b/tooltips.scss
@@ -88,7 +88,7 @@ $largeScreen: 1400px;
     z-index: 98;
     @include transition(opacity $fade, visibility 0ms linear $fade); // delay visibility on fade out
     pointer-events: none;
-    @include respondTo(smartphone){ display: none; }
+    @include respondTo(smartphone){ display: none !important; }
   }
   &:before { // tooltip body
     content: attr(data-tooltip);


### PR DESCRIPTION
override `{ display: block; }` in triangle mixin.
